### PR TITLE
pass default callback to metalsmith .build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-prismic-server",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "server to compile and preview static sites from prismic.io content",
   "main": "index.js",
   "scripts": {

--- a/src/build.js
+++ b/src/build.js
@@ -6,7 +6,11 @@ function build(config, modes, cb) {
   config = Object.assign({}, DEFAULT_CONFIG, config);
   metalsmith(config, modes)
     .destination(path.join(config.buildPath, "master"))
-    .build(cb);
+    .build(cb || (err => {
+      if (err) {
+        throw err;
+      }
+    }));
 }
 
 module.exports = build;


### PR DESCRIPTION
apparently the build silently fails if you pass undefined.
