### PR TITLE
allow specifying whether to do initial build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-prismic-server",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "server to compile and preview static sites from prismic.io content",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/futurice/metalsmith-prismic-server.git"
   },
   "author": "ds300",
-  "license": "todo",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/futurice/metalsmith-prismic-server/issues"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -98,5 +98,10 @@ module.exports = {
   /**
    * Metalsmith prismic plugin to use
    */
-   prismic: prismic
+   prismic: prismic,
+
+   /**
+    * Do initial build/deploy when prod server starts.
+    */
+  doInitialBuild: true,
 };

--- a/src/prod-server.js
+++ b/src/prod-server.js
@@ -24,21 +24,30 @@ const DEAFULT_CONFIG = require('./config');
 function prod(config) {
   config = Object.assign({}, DEAFULT_CONFIG, config);
 
-  const app = express();
-  app.use(bodyParser.json());
-  app.use('/builds', express.static(config.buildPath));
 
-  buildRoute(app, config);
-  previewRoute(app, config);
+  function init() {
+    const app = express();
+    app.use(bodyParser.json());
+    app.use('/builds', express.static(config.buildPath));
 
-  app.listen(config.port);
+    buildRoute(app, config);
+    previewRoute(app, config);
 
-  // do initial build
-  build(config, ['build', 'deploy'], err => {
-    if (err) {
-      throw err;
-    }
-  });
+    app.listen(config.port);
+  }
+
+  if (config.doInitialBuild) {
+    // do initial build
+    build(config, ['build', 'deploy'], err => {
+      if (err) {
+        throw err;
+      } else {
+        init();
+      }
+    });
+  } else {
+    init();
+  }
 }
 
 function reject(response, message) {


### PR DESCRIPTION
we had some concurrency problems with azure whereby the server would not be started until a relevant route was requested. As part of the server initialisation phase, a build/deploy was triggered. It turns out that requesting a `/build` while a build is already in progress can cause concurrency problems when you are deploying to azure storage using the official sdk.
